### PR TITLE
#1 add redis caching on getting product by code

### DIFF
--- a/src/main/java/np/com/esewa/learn/sampleapplication/SampleApplication.java
+++ b/src/main/java/np/com/esewa/learn/sampleapplication/SampleApplication.java
@@ -2,10 +2,12 @@ package np.com.esewa.learn.sampleapplication;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableScheduling //Enables scheduling
+@EnableCaching // enables caching
 public class SampleApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/np/com/esewa/learn/sampleapplication/inventory/config/cache/ProductByCodeRedisCacheConfig.java
+++ b/src/main/java/np/com/esewa/learn/sampleapplication/inventory/config/cache/ProductByCodeRedisCacheConfig.java
@@ -1,0 +1,52 @@
+package np.com.esewa.learn.sampleapplication.inventory.config.cache;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurer;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class ProductByCodeRedisCacheConfig implements CachingConfigurer {
+
+    @Autowired
+    private RedisConnectionFactory redisConnectionFactory;
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(Object.class));
+        return template;
+    }
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheManager.RedisCacheManagerBuilder builder = RedisCacheManager
+                .RedisCacheManagerBuilder
+                .fromConnectionFactory(redisConnectionFactory);
+        return builder.build();
+    }
+
+    @Bean
+    public RedisCacheConfiguration cacheConfiguration() {
+        return RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10)) // cache for 10 minutes (time to live)
+                .disableCachingNullValues() // will not cache null values
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new Jackson2JsonRedisSerializer<>(Object.class)));
+    }
+
+}

--- a/src/main/java/np/com/esewa/learn/sampleapplication/inventory/config/database/ProductDatabaseConfig.java
+++ b/src/main/java/np/com/esewa/learn/sampleapplication/inventory/config/database/ProductDatabaseConfig.java
@@ -1,4 +1,4 @@
-package np.com.esewa.learn.sampleapplication.inventory.config;
+package np.com.esewa.learn.sampleapplication.inventory.config.database;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/np/com/esewa/learn/sampleapplication/inventory/service/ProductServiceImpl.java
+++ b/src/main/java/np/com/esewa/learn/sampleapplication/inventory/service/ProductServiceImpl.java
@@ -9,6 +9,7 @@ import np.com.esewa.learn.sampleapplication.inventory.model.Product;
 import np.com.esewa.learn.sampleapplication.inventory.model.ProductStatus;
 import np.com.esewa.learn.sampleapplication.inventory.repository.ProductRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 import java.io.BufferedReader;
@@ -78,6 +79,11 @@ public class ProductServiceImpl implements ProductService {
         return countDto;
     }
 
+    /*
+    * set cache name to productByCodeCache and add caching at get request
+    * as cache is maintained in ConcurrentHashMap key will be productCode
+    */
+    @Cacheable(cacheNames = {"productByCodeCache"}, key = "productCode")
     @Override
     public ProductResponseDto getProductByCode(String productCode) {
         Product product = productRepository.findProductByCode(productCode);


### PR DESCRIPTION
Added, cache configuration for Redis and enable caching while getting product by code.

- For first time the request will hit a trigger to database for getting product of that code. 
- From next time it will be returned from redis cache. So, that there will be less load on database.
- Will not cache null values, as they doesn't add meaning to reside on cache